### PR TITLE
Add simple `Inciweb::Request` client

### DIFF
--- a/inciweb.gemspec
+++ b/inciweb.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 2.0"
 end

--- a/lib/inciweb.rb
+++ b/lib/inciweb.rb
@@ -1,5 +1,5 @@
 require "inciweb/version"
+require "inciweb/request"
 
 module Inciweb
-  # Your code goes here...
 end

--- a/lib/inciweb/request.rb
+++ b/lib/inciweb/request.rb
@@ -1,0 +1,34 @@
+require "uri"
+require "net/http"
+
+module Inciweb
+  class Request
+    def initialize(path)
+      @path = path
+    end
+
+    def run
+      execute_request
+    end
+
+    def self.get(path)
+      new(path).run
+    end
+
+    private
+
+    attr_reader :path, :inciweb_host
+
+    def execute_request
+      Net::HTTP.get(build_inciweb_uri)
+    end
+
+    def build_inciweb_uri
+      URI([inciweb_host, path].join("/"))
+    end
+
+    def inciweb_host
+      @inciweb_host ||= "https://inciweb.nwcg.gov"
+    end
+  end
+end

--- a/spec/inciweb/request_spec.rb
+++ b/spec/inciweb/request_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe Inciweb::Request do
+  describe ".get" do
+    it "retrieves the resource via http get" do
+      stub_inciweb_ping_request(status: 200)
+
+      http_response = Inciweb::Request.get("ping")
+
+      expect(http_response).to eq("Pong!")
+    end
+  end
+
+  def stub_inciweb_ping_request(status: 200)
+    stub_request(:get, "https://inciweb.nwcg.gov/ping").
+      to_return(body: "Pong!", status: status)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "webmock/rspec"
 require "bundler/setup"
 require "inciweb"
 


### PR DESCRIPTION
This commit adds a simple api client `Inciweb::Request`, this is only preparing the request URI and then requesting the resource via `http get` for now, but we will more customized behavior as necessary in the near future.