### PR TITLE
Retrieve the list of recent incidents

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ gem "inciweb", path: "lib/inciweb"
 
 ## Usage
 
+### List Incidents
+
+This gem provides a very easier way to retrieve the list of recent incidents,
+and we can retrieve those using the following interface.
+
+```ruby
+Inciweb::Incident.all
+```
 
 ## Development
 

--- a/inciweb.gemspec
+++ b/inciweb.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
   spec.required_ruby_version = Gem::Requirement.new(">= 2.1.9")
 
+  spec.add_dependency "activesupport", "~> 5.0.1"
+
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/inciweb.rb
+++ b/lib/inciweb.rb
@@ -1,5 +1,6 @@
 require "inciweb/version"
 require "inciweb/request"
+require "inciweb/incident"
 
 module Inciweb
 end

--- a/lib/inciweb/incident.rb
+++ b/lib/inciweb/incident.rb
@@ -1,0 +1,19 @@
+module Inciweb
+  class Incident
+    def all
+      fetch_incidents
+    end
+
+    def self.all
+      new.all
+    end
+
+    private
+
+    def fetch_incidents
+      Inciweb::Response.from_xml(
+        Inciweb::Request.new("feeds/rss/incidents/").run
+      )
+    end
+  end
+end

--- a/lib/inciweb/request.rb
+++ b/lib/inciweb/request.rb
@@ -1,5 +1,6 @@
 require "uri"
 require "net/http"
+require "inciweb/response"
 
 module Inciweb
   class Request

--- a/lib/inciweb/response.rb
+++ b/lib/inciweb/response.rb
@@ -1,0 +1,28 @@
+require "json"
+require "ostruct"
+
+require "active_support"
+require "active_support/core_ext"
+
+module Inciweb
+  class Response
+    attr_reader :document
+
+    def initialize(document)
+      @document = document
+    end
+
+    def parse
+      if document
+        JSON.parse(document, object_class: ResponseObject)
+      end
+    end
+
+    def self.from_xml(xml_body)
+      response_hash = Hash.from_xml(xml_body)
+      new(response_hash["rss"]["channel"]["item"].to_json).parse
+    end
+  end
+
+  class ResponseObject < OpenStruct; end
+end

--- a/spec/fixtures/incidents.xml
+++ b/spec/fixtures/incidents.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+cached data at 01:51:11
+cached id 76aaeee55f1a2cd366a5162c3f82fb79
+-->
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:georss="http://www.georss.org/georss" xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#">
+  <channel>
+    <atom:link href="https://inciweb.nwcg.gov/feeds/rss/incidents/" rel="self" type="application/rss+xml" />
+    <title>InciWeb National Incidents</title>
+    <link>https://inciweb.nwcg.gov</link>
+    <description>Latest incident updates nationally</description>
+    <pubDate>Mon, 24 Jul 2017 01:51:11 -05:00</pubDate>
+    <language>en-us</language>
+    <item>
+      <title>Whetstone Ridge Fire</title>
+      <published>Mon, 24 Jul 2017 00:00:34 -05:00</published>
+      <pubDate>Mon, 24 Jul 2017 00:00:34 -05:00</pubDate>
+      <georss:point>46.048888888889 -113.64666666667</georss:point>
+      <geo:lat>46.048888888889</geo:lat>
+      <geo:long>-113.64666666667</geo:long>
+      <link>https://inciweb.nwcg.gov/incident/5363/</link>
+      <guid isPermaLink="true">https://inciweb.nwcg.gov/incident/5363/</guid>
+      <description>  The fire was relatively quiet yesterday but smoke was visible in the Georgetown Lake and Philipsburg communities. A spot was discovered ½ mile east of the main fire perimeter. Helicoptors dropped several buckets of water to slow down spots outside the perimeter. Structures were assessed for structure protection in Frog Pond Basin. The predicted weather for today is to be hotter and drier with calmer winds. A new Area Closure was implemented for the Whetsone Ridge and Meyers Fires. Lakes affected by the Closure are Kaiser Lake, Moose Lake, Whetstone Lake and Green Canyon Lake. Moose Lake Road #5106 is open to local traffic only and Ross Fork Road #70 is closed south of Milo Lake. The Copper Creek Road #80 is closed at the junction with Moose Lake Road #5106 and Copper Creek Campground is closed.  For a detailed description and map of the Area Closure, go online to go to http://inciweb.nwcg.gov/    The temporary flight restriction (TFR) has been enlarged significantly to encompass...</description>
+    </item>
+    <item>
+      <title>Cedar Mountain Fire (Wildfire)</title>
+      <published>Fri, 21 Jul 2017 10:51:17 -05:00</published>
+      <pubDate>Fri, 21 Jul 2017 10:51:17 -05:00</pubDate>
+      <georss:point>40.705 -112.955</georss:point>
+      <geo:lat>40.705</geo:lat>
+      <geo:long>-112.955</geo:long>
+      <link>https://inciweb.nwcg.gov/incident/5391/</link>
+      <guid isPermaLink="true">https://inciweb.nwcg.gov/incident/5391/</guid>
+      <description>On Monday, July 17 at 1914, an active lightning storm traveled across the Cedar Mountains starting several fires. Crew were dispatched and were successful in quickly extinguishing some of the fires. The remaining fires grew together and formed the Cedar Mountain fire. It is being commanded by the Onaqui Mountain Complex Incident Management Team.</description>
+    </item>
+    <item>
+      <title>Onaqui Mountain Complex (Wildfire)</title>
+      <published>Fri, 21 Jul 2017 10:02:46 -05:00</published>
+      <pubDate>Fri, 21 Jul 2017 10:02:46 -05:00</pubDate>
+      <georss:point>40.181666666667 -112.54611111111</georss:point>
+      <geo:lat>40.181666666667</geo:lat>
+      <geo:long>-112.54611111111</geo:long>
+      <link>https://inciweb.nwcg.gov/incident/5381/</link>
+      <guid isPermaLink="true">https://inciweb.nwcg.gov/incident/5381/</guid>
+      <description> 07/21/17Last update pending any significant events or change in fire behavior. On Sunday, July 16 at around 1700, an active lightning storm traveled across the Onaqui (on-ah-key) Mountains starting several fires. Crew were dispatched and were successful in quickly extinguishing some of the fires, while others continued to grow. With many incidents around the state, managers are treating these individual fires as one large incident (a complex) in an effort to be efficient and effective with limited</description>
+    </item>
+  </channel>
+</rss>

--- a/spec/inciweb/incident_spec.rb
+++ b/spec/inciweb/incident_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe Inciweb::Incident do
+  describe ".all" do
+    it "retrieves all of the recent incidents" do
+      stub_listing_incidents_api_call
+
+      incidents = Inciweb::Incident.all
+
+      expect(incidents.count).to eq(3)
+      expect(incidents.last.lat).to eq("40.181666666667")
+      expect(incidents.last.long).to eq("-112.54611111111")
+      expect(incidents.first.title).to eq("Whetstone Ridge Fire")
+    end
+  end
+end

--- a/spec/inciweb/response_spec.rb
+++ b/spec/inciweb/response_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe Inciweb::Response do
+  describe ".from_xml" do
+    it "parse the xml document to ResponseObject" do
+      response_object = Inciweb::Response.from_xml(incidents_fixture)
+
+      expect(response_object.first.title).to eq("Whetstone Ridge Fire")
+      expect(response_object.first.class).to eq(Inciweb::ResponseObject)
+    end
+  end
+
+  def incidents_fixture
+    inciweb_fixture("incidents.xml")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,12 +2,16 @@ require "webmock/rspec"
 require "bundler/setup"
 require "inciweb"
 
+Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
+
+  config.include Inciweb::FakeInciwebApi
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/fake_inciweb_api.rb
+++ b/spec/support/fake_inciweb_api.rb
@@ -1,0 +1,24 @@
+module Inciweb
+  module FakeInciwebApi
+    def stub_listing_incidents_api_call
+      stub_api_response("feeds/rss/incidents/", filename: "incidents.xml")
+    end
+
+    private
+
+    def stub_api_response(path, filename:, status: 200)
+      stub_request(:get, inciweb_uri(path)).to_return(
+        body: inciweb_fixture(filename), status: status,
+      )
+    end
+
+    def inciweb_uri(path)
+      ["https://inciweb.nwcg.gov", path].join("/")
+    end
+
+    def inciweb_fixture(filename)
+      file_path = ["../../fixtures", filename].join("/")
+      File.read(File.expand_path(file_path, __FILE__))
+    end
+  end
+end


### PR DESCRIPTION
The `InciWeb` provides a RSS feed which returns the list of recent incidents, and this commit adds the interface to retrieve all of those incidents and parse those in a very simpler ruby object.

For simplicity it's parsing the contents to `ResponseObject`, but in the future we might want to create dedicated ruby instance, so to retrieve the incidents we can use

```ruby
Inciweb::Incident.all
```