### PR TITLE
Interface to retrieve an incident details

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ and we can retrieve those using the following interface.
 Inciweb::Incident.all
 ```
 
+### Find an Incident
+
+The incidents listing interface only provides the basic information, but in
+some rare cases we might need the status, size of affected area, or any other
+details, and that's where the `find` interface fits. Currently it will only
+return the additional details but in the future we can add more attributes to it
+
+```ruby
+Inciweb::Incident.find(incident_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/inciweb.gemspec
+++ b/inciweb.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.1.9")
 
   spec.add_dependency "activesupport", "~> 5.0.1"
+  spec.add_dependency "nokogiri", "~> 1.6"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/inciweb/incident.rb
+++ b/lib/inciweb/incident.rb
@@ -1,18 +1,38 @@
 module Inciweb
   class Incident
+    def initialize(id = nil)
+      @id = id
+    end
+
     def all
       fetch_incidents
+    end
+
+    def find
+      fetch_incident
     end
 
     def self.all
       new.all
     end
 
+    def self.find(incident_id)
+      new(incident_id).find
+    end
+
     private
+
+    attr_reader :id
 
     def fetch_incidents
       Inciweb::Response.from_xml(
         Inciweb::Request.new("feeds/rss/incidents/").run
+      )
+    end
+
+    def fetch_incident
+      Inciweb::Response.from_html(
+        Inciweb::Request.new(["incident", id, ""].join("/")).run
       )
     end
   end

--- a/lib/inciweb/incident_parser.rb
+++ b/lib/inciweb/incident_parser.rb
@@ -1,0 +1,71 @@
+require "nokogiri"
+
+module Inciweb
+  class IncidentParser
+    def initialize(document)
+      @document = nokogiri_doc(document)
+    end
+
+    def parse
+      parse_document
+    end
+
+    def self.parse(document)
+      new(document).parse
+    end
+
+    private
+
+    attr_reader :document
+
+    def nokogiri_doc(document)
+      Nokogiri::HTML(document)
+    end
+
+    def parse_document
+      {
+        title: incident_title,
+        lat: incident_lat,
+        long: incident_long,
+        size: incident_size,
+        cause: incident_cause,
+        active: incident_status,
+        incident_type: incident_type,
+      }
+    end
+
+    def incident_title
+      document.css("#top h2").text
+    end
+
+    def incident_lat
+      scan_document(/(\d+.\.\d+.) latitude/)
+    end
+
+    def incident_long
+      scan_document(/(-\d+.\.\d+.) longitude/)
+    end
+
+    def incident_size
+      content = document.css("table").text.gsub(",", "")
+      scan_document(/Size(\w+) Acres/, "table", content)
+    end
+
+    def incident_type
+      scan_document(/Type(\w+)Cause/, "table")
+    end
+
+    def incident_cause
+      scan_document(/Cause(\w+)Date/)
+    end
+
+    def incident_status
+      scan_document(/This incident is no longer being updated./).nil?
+    end
+
+    def scan_document(pattern, css = "body", content = nil)
+      content ||= document.css(css).text
+      content.scan(pattern).flatten.first
+    end
+  end
+end

--- a/lib/inciweb/response.rb
+++ b/lib/inciweb/response.rb
@@ -3,6 +3,7 @@ require "ostruct"
 
 require "active_support"
 require "active_support/core_ext"
+require "inciweb/incident_parser"
 
 module Inciweb
   class Response
@@ -21,6 +22,11 @@ module Inciweb
     def self.from_xml(xml_body)
       response_hash = Hash.from_xml(xml_body)
       new(response_hash["rss"]["channel"]["item"].to_json).parse
+    end
+
+    def self.from_html(html_body)
+      response_hash = Inciweb::IncidentParser.parse(html_body)
+      new(response_hash.to_json).parse
     end
   end
 

--- a/spec/fixtures/incident.html
+++ b/spec/fixtures/incident.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Potosi Fire</title>
+    </head>
+  <body>
+    <div id="wrap">
+      <div id="top">
+        <div id="drop_block">
+          <form action="#" method="post" id="form_nav">
+            <div style="width: 320px; text-align: right;">
+              <div style="width: 130px; float: left;"><label for="inc_id">Select an incident</label></div>
+              <div style="width: 160px; display: inline;">
+                <!-- 
+                  cached incident dropdown at 04:52:43
+                  cached id 56a9c5e8134b5d9e6b44fe62eaecbbec
+                -->
+                <select name="inc_id" id="inc_id" class="select_width" tabindex="1">
+                  <option value="" selected="selected">incident</option>
+                </select></div>
+            </div>
+            <div style="width: 320px; text-align: right;">
+              <div style="width: 130px; float: left;"><label for="state_id">Select a state</label></div>
+              <div style="width: 160px; display: inline;">
+                <!-- 
+                  cached state dropdown at 04:52:43
+                  cached id 0a94f14ee4656420f989a28dad297a78
+                -->
+                <select name="state_id" id="state_id" class="select_width" tabindex="2">
+                  <option value="" selected="selected">state</option>
+                </select></div>
+            </div>
+            <div><input name="jump" class="button" type="submit" value="go" tabindex="3" /></div>
+          </form>
+        </div>
+
+        <h1><a href="/" title="InciWeb - Incident Information System">InciWeb - Incident Information System</a></h1>
+        <!--  <div class="banner" id="bannerid"><b></b></div>-->
+        <p class="hide"><a href="#content">[Skip to content]</a></p>
+
+        <div id="crumbs"><ul id="navlist"><li><a href="/" title="incidents">Incidents</a>&nbsp;&gt; </li><li><a href="/state/29/" title="NEVADA incidents">NEVADA</a>&nbsp;&gt; </li><li><a href="/unit/43/" title="Humboldt-Toiyabe National Forest incidents">Humboldt-Toiyabe National Forest</a>&nbsp;&gt; </li><li class="active">Potosi Fire</li></ul></div>
+
+        <h2>Potosi Fire</h2>
+
+        <div id="main_menu"><ul id="menu"><li>Incident Information</li><li><a href="/incident/announcements/5331/" title="Potosi Fire announcements">Announcements</a></li><li><a href="/incident/closures/5331/" title="Potosi Fire closures">Closures</a></li><li><a href="/incident/news/5331/" title="Potosi Fire news releases">News</a></li><li><a href="/incident/photographs/5331/" title="Potosi Fire photographs">Photographs</a></li><li><a href="/incident/maps/5331/" title="Potosi Fire maps">Maps</a></li></ul> </div>
+      </div>
+
+      <div id="content">
+
+
+
+        <div id="modified">INCIDENT UPDATED 4 DAYS AGO</div><h3>Approximate Location</h3><div>
+
+          <!--  Commented out GoogleMaps API to change to ESRI Map Service
+            <script type="text/javascript"    src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDV7JiYnvlKzhGavFcXV7qhU28o4S8PC1k&sensor=false">    </script>
+            -->
+            35.927 latitude, -115.54 longitude
+            <input class="button" type="button" value="zoom to incident" onclick="resetMap();"/>
+            <div style="display: inline;" id="perimetersdescdiv"></div><div  id="perimetersdiv"></div><div id="box_google_map" class="tundra"></div></div><h3>Incident Overview</h3><div><p><font color="#000000">The Potosi Fire is burning on the west side of Potosi Mountain on the Humboldt-Toiyabe National Forest’s Spring Mountain National Recreation Area near Las Vegas. Currently, the fire is 100% contained and in patrol status. </font></p></div><br style="clear: right;" /><h4>Basic Information</h4><table cellpadding="0" cellspacing="0" class="data" summary="This table displays basic incident information."><tr><th scope="row" class="cell0" style="width: 30%;">Current as of</th><td class="cell3"><script>var clientdate = new Date("2017-07-20T14:19:19-05:00");document.write(clientdate.toLocaleString())</script></td></tr><tr><th scope="row" class="cell1">Incident Type</th><td class="cell2">Wildfire</td></tr><tr><th scope="row" class="cell1">Cause</th><td class="cell2">Lightning</td></tr><tr><th scope="row" class="cell1">Date of Origin</th><td class="cell2">Thursday July 06th, 2017 approx.   07:00 PM</td></tr><tr><th scope="row" class="cell1">Incident Commander</th><td class="cell2">Humboldt-Toiyabe National Forest</td></tr></table><h4>Current Situation</h4><table cellpadding="0" cellspacing="0" class="data" summary="This table displays the situation information."><tr><th scope="row" class="cell0" style="width: 30%;">Size</th><td class="cell3">420 Acres</td></tr><tr><th scope="row" class="cell1">Percent of Perimeter Contained</th><td class="cell2">100%</td></tr><tr><th scope="row" class="cell1">Fuels Involved</th><td class="cell2"><p>Pinyon-Juniper</p></td></tr></table><h4>Outlook</h4><table cellpadding="0" cellspacing="0" class="data" summary="This table displays outlook information."><tr><th scope="row" class="cell0" style="width: 30%;">Projected Incident Activity</th><td class="cell3"><p>In patrol status. </p>
+
+                <p></p></td></tr><tr><th scope="row" class="cell1">Remarks</th><td class="cell2"><p>100% control anticipated at end of week. </p></td></tr></table>
+      </div>
+
+      <!-- end content -->
+
+      <div id="rightnav">
+        <h3 class="right_head">Unit Information</h3><div class="right_block"><img src="/images/shields/usfs.gif" alt="USFS Shield" id="unit_shield"/><div id="unit_address"><a href="http://www.fs.usda.gov/r4/htnf/" title="exits web site">Humboldt-Toiyabe National Forest</a><br />U.S. Forest Service<br />1200 Franklin Way <br />Sparks, NV 89431<br/><a href="https://www.facebook.com/HumboldtToiyabeNF/" title="Link to facebook"><img src="/images/icons/facebook.gif" alt="Facebook" id="ufacebookicon"/></a><br /></div></div><h3 class="right_head">Incident Contact</h3><div class="right_block"><div id="contact">
+            <!-- 
+              cached column contacts at 04:46:49
+              cache id b0f5cba1dc4633e86155e050f41beac0
+            -->
+            <div><strong>Marnie Bonesteel</strong><br/><span class="smaller">Email: <a href="/incident/mail/5331/8744/">htnfinfo@gmail.com</a></span><br/><span class="smaller">Phone: 775-741-2623</span><br /><span class="smaller">Hours: 8am-9pm</span></div></div></div><h3 class="right_head">Recent Articles</h3><div class="right_block"><ul class="right_list">
+            <!-- 
+              cached column articles at 04:46:49
+              cached id 5c52cb3b1872663775edee2180be10ee
+            -->
+            <li><a href="/incident/article/5331/36329/">Potosi Fire Update July 10, 2017 at 8 p.m. </a><br /><span class="smaller"><strong>News</strong> - 7/10/2017</span></li><li><a href="/incident/article/5331/36285/">Potosi Fire Update July 9, 2017 at 7:15p.m.</a><br /><span class="smaller"><strong>News</strong> - 7/9/2017</span></li><li><a href="/incident/article/5331/36258/">Potosi Fire Update July 9, 2017 at 9 a.m.</a><br /><span class="smaller"><strong>News</strong> - 7/9/2017</span></li><li><a href="/incident/article/5331/36241/">Potosi Fire Update July 8, 2017 at 7:30 p.m.</a><br /><span class="smaller"><strong>News</strong> - 7/8/2017</span></li></ul></div><h3 class="right_head">Related Incident Links</h3><div class="right_block"><ul class="right_list">
+            <!-- 
+              cached column related links at 04:46:49
+              cached id 2ca9d046bb936fbde7b6ef0d0c76d446
+            -->
+            <li><a href="https://www.facebook.com/HumboldtToiyabeNF/" rel="external">Humboldt-Toiyabe National Forest Facebook Page</a></li><li><a href="https://twitter.com/HumboldtToiyabe?lang=en" rel="external">Humboldt-Toiyabe National Forest Twitter Page</a></li></ul></div><h3 class="right_head">Follow this Incident</h3><div class="right_block"><ul class="feed-list"><li class="twitter"><a href="https://twitter.com/search?q=%23PotosiFire" target="_blank">Twitter Feed</a></li><li class="feed-rss"><a href="/feeds/rss/articles/incident/5331/" title="this Incident article feed">Article RSS Feed</a></li><li class="feed-ge"><a href="/feeds/maps/incident/5331/" title="this Incident GoogleEarth feed">Google Earth Network Feed</a></li></ul><div class="feed-help"><a href="/feeds/" class="smaller bold">help&nbsp;&raquo;</a></div></div><h3 class="right_head">Fire Information Websites</h3><div class="right_block"><ul class="feed-list">    
+            <li><a href="/links/">Incident Related Links</a></li>     
+            <li><a href="http://cdfdata.fire.ca.gov/incidents/incidents_current" target="_blank">CalFire Incident Information</a></li>
+          </ul></div><h3 class="right_head">Share This</h3><div class="right_block"><ul class="feed-list">         
+              <li class="twitter"><a href="http://twitter.com/home/?status=%40inciweb+%23PotosiFire+https%3A%2F%2Finciweb.nwcg.gov%2Fincident%2F5331%2F" target="_blank">Twitter</a></li>         
+              <li class="facebook"><a href="http://www.facebook.com/sharer.php?u=https://inciweb.nwcg.gov/incident/5331/" target="_blank">Facebook</a></li>
+            </ul></div>        </div>   <div id="footer">
+              <ul id="menu_footer">
+                <li><a href="/links/">Links</a></li>
+                <li><a href="/terminology/">Terminology</a></li>
+                <li><a href="/about/">About This Site</a></li>
+                <li><a href="/help/">Help</a></li>
+                <li><a href="/disclaimer/">Disclaimer</a></li>
+                <li><a href="/feeds/">Feeds</a></li>
+                <li><a href="https://nap.nwcg.gov/NAP/" target="_blank">Log In</a></li>
+              </ul>
+            </div>
+            <!-- end footer -->
+    </div>
+    <!-- end wrap -->
+    <div id="nifc_agencies"></div>
+
+
+    <div id="disclaimer">Content posted to this website is for information purposes only.</div>
+
+    <div id="performance"> 
+      version: 2.4&nbsp; &nbsp; &nbsp; 
+      load time: 0.00046 sec.
+    </div>
+  </body>
+</html>

--- a/spec/inciweb/incident_parser_spec.rb
+++ b/spec/inciweb/incident_parser_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe Inciweb::IncidentParser do
+  describe ".parse" do
+    it "parse the html document to a hash" do
+      document = Inciweb::IncidentParser.parse(incident_fixture)
+
+      expect(document[:size]).to eq("420")
+      expect(document[:active]).to be_truthy
+      expect(document[:title]).to eq("Potosi Fire")
+      expect(document[:incident_type]).to eq("Wildfire")
+    end
+  end
+
+  def incident_fixture
+    inciweb_fixture("incident.html")
+  end
+end

--- a/spec/inciweb/incident_spec.rb
+++ b/spec/inciweb/incident_spec.rb
@@ -13,4 +13,17 @@ RSpec.describe Inciweb::Incident do
       expect(incidents.first.title).to eq("Whetstone Ridge Fire")
     end
   end
+
+  describe ".find" do
+    it "retrieves the details for an incident" do
+      incident_id = 123456
+      stub_incident_find_api_call(incident_id)
+
+      incident = Inciweb::Incident.find(incident_id)
+
+      expect(incident.size).to eq("420")
+      expect(incident.title).to eq("Potosi Fire")
+      expect(incident.incident_type).to eq("Wildfire")
+    end
+  end
 end

--- a/spec/inciweb/response_spec.rb
+++ b/spec/inciweb/response_spec.rb
@@ -10,6 +10,18 @@ RSpec.describe Inciweb::Response do
     end
   end
 
+  describe ".from_html" do
+    it "parse the html document to ResponseObject" do
+      incident_page = inciweb_fixture("incident.html")
+
+      response_object = Inciweb::Response.from_html(incident_page)
+
+      expect(response_object.size).to eq("420")
+      expect(response_object.title).to eq("Potosi Fire")
+      expect(response_object.incident_type).to eq("Wildfire")
+    end
+  end
+
   def incidents_fixture
     inciweb_fixture("incidents.xml")
   end

--- a/spec/support/fake_inciweb_api.rb
+++ b/spec/support/fake_inciweb_api.rb
@@ -4,6 +4,12 @@ module Inciweb
       stub_api_response("feeds/rss/incidents/", filename: "incidents.xml")
     end
 
+    def stub_incident_find_api_call(incident_id)
+      stub_api_response(
+        ["incident", incident_id, ""].join("/"), filename: "incident.html"
+      )
+    end
+
     private
 
     def stub_api_response(path, filename:, status: 200)


### PR DESCRIPTION
This commit adds the interface to retrieve the additional details for any of the existing incidents, currently we have limited it's attributes to `lat`, `long`, `size`, `cause` and `incident_type` but we can easily extend that by adding additional method to the `Inciweb::IncidentParser`. Use

```ruby
Inciweb::Incident.find(incident_id)
```