### PR TITLE
Add `find_by_link` interface for incident

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ return the additional details but in the future we can add more attributes to it
 Inciweb::Incident.find(incident_id)
 ```
 
+### Find by link
+
+The `inciweb` does not provide the incident id directly with their response, we
+can normally extract this from the `link`, but lets make it more simpler, this
+interface takes the link as an argument and then extract the id and retrieve the
+details for that specific incident.
+
+```ruby
+Inciweb::Incident.find_by_link(incident_link)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,8 @@
+dependencies:
+  override:
+    - gem install bundler -v "~> 1.15"
+
 test:
   override:
+    - bundle install
     - bundle exec rspec

--- a/lib/inciweb/incident.rb
+++ b/lib/inciweb/incident.rb
@@ -20,6 +20,11 @@ module Inciweb
       new(incident_id).find
     end
 
+    def self.find_by_link(link)
+      incident_id = link.to_s.scan(/\d+/)
+      new(incident_id).find
+    end
+
     private
 
     attr_reader :id

--- a/lib/inciweb/version.rb
+++ b/lib/inciweb/version.rb
@@ -1,3 +1,3 @@
 module Inciweb
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/inciweb/incident_spec.rb
+++ b/spec/inciweb/incident_spec.rb
@@ -26,4 +26,17 @@ RSpec.describe Inciweb::Incident do
       expect(incident.incident_type).to eq("Wildfire")
     end
   end
+
+  describe ".find_by_link" do
+    it "retrieves the details by an incident link" do
+      link = "https://inciweb.nwcg.gov/incident/123456/"
+
+      stub_incident_find_api_call(123456)
+      incident = Inciweb::Incident.find_by_link(link)
+
+      expect(incident.size).to eq("420")
+      expect(incident.title).to eq("Potosi Fire")
+      expect(incident.incident_type).to eq("Wildfire")
+    end
+  end
 end


### PR DESCRIPTION
InciWeb response does not have any attributes for id, so this commit simplify this process and it takes an incident link and then extract the id and finally retrieve the details for that specific incident.

```ruby
Inciweb::Incident.find_by_link(incident_link)
```